### PR TITLE
Use prek

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ indent_size = 4
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.yaml]
+indent_size = 2

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: 🏗 Install Python dependencies
         run: poetry install --no-interaction
       - name: 🚀 Check code for common misspellings
-        run: poetry run pre-commit run codespell --all-files
+        run: poetry run prek run codespell --all-files
 
   ruff:
     name: Ruff
@@ -61,6 +61,37 @@ jobs:
       - name: 🚀 Run ruff formatter
         run: poetry run ruff format --check .
 
+  prek-builtin-hooks:
+    name: prek-builtin-hooks
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@v6.0.2
+      - name: 🏗 Install prek
+        run: pipx install prek
+      - name: 🚀 Check for case conflicts
+        run: prek run check-case-conflict --all-files
+      - name: 🚀 Check that executables have shebangs
+        run: prek run check-executables-have-shebangs --all-files
+      - name: 🚀 Check JSON files
+        run: prek run check-json --all-files
+      - name: 🚀 Check for merge conflicts
+        run: prek run check-merge-conflict --all-files
+      - name: 🚀 Check for broken symlinks
+        run: prek run check-symlinks --all-files
+      - name: 🚀 Check TOML files
+        run: prek run check-toml --all-files
+      - name: 🚀 Check XML files
+        run: prek run check-xml --all-files
+      - name: 🚀 Check YAML files
+        run: prek run check-yaml --all-files
+      - name: 🚀 Detect Private Keys
+        run: prek run detect-private-key --all-files
+      - name: 🚀 Check End of Files
+        run: prek run end-of-file-fixer --all-files
+      - name: 🚀 Trim Trailing Whitespace
+        run: prek run trailing-whitespace --all-files
+
   pre-commit-hooks:
     name: pre-commit-hooks
     runs-on: ubuntu-latest
@@ -82,31 +113,9 @@ jobs:
       - name: 🏗 Install Python dependencies
         run: poetry install --no-interaction
       - name: 🚀 Check Python AST
-        run: poetry run pre-commit run check-ast --all-files
-      - name: 🚀 Check for case conflicts
-        run: poetry run pre-commit run check-case-conflict --all-files
+        run: poetry run prek run check-ast --all-files
       - name: 🚀 Check docstring is first
-        run: poetry run pre-commit run check-docstring-first --all-files
-      - name: 🚀 Check that executables have shebangs
-        run: poetry run pre-commit run check-executables-have-shebangs --all-files
-      - name: 🚀 Check JSON files
-        run: poetry run pre-commit run check-json --all-files
-      - name: 🚀 Check for merge conflicts
-        run: poetry run pre-commit run check-merge-conflict --all-files
-      - name: 🚀 Check for broken symlinks
-        run: poetry run pre-commit run check-symlinks --all-files
-      - name: 🚀 Check TOML files
-        run: poetry run pre-commit run check-toml --all-files
-      - name: 🚀 Check XML files
-        run: poetry run pre-commit run check-xml --all-files
-      - name: 🚀 Check YAML files
-        run: poetry run pre-commit run check-yaml --all-files
-      - name: 🚀 Detect Private Keys
-        run: poetry run pre-commit run detect-private-key --all-files
-      - name: 🚀 Check End of Files
-        run: poetry run pre-commit run end-of-file-fixer --all-files
-      - name: 🚀 Trim Trailing Whitespace
-        run: poetry run pre-commit run trailing-whitespace --all-files
+        run: poetry run prek run check-docstring-first --all-files
 
   pylint:
     name: pylint
@@ -129,7 +138,7 @@ jobs:
       - name: 🏗 Install Python dependencies
         run: poetry install --no-interaction
       - name: 🚀 Run pylint
-        run: poetry run pre-commit run pylint --all-files
+        run: poetry run prek run pylint --all-files
 
   yamllint:
     name: yamllint
@@ -182,4 +191,4 @@ jobs:
       - name: 🏗 Install NPM dependencies
         run: npm install
       - name: 🚀 Run prettier
-        run: poetry run pre-commit run prettier --all-files
+        run: poetry run prek run prettier --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,51 +21,11 @@ repos:
         language: system
         types: [python]
         entry: poetry run check-ast
-      - id: check-case-conflict
-        name: 🔠 Check for case conflicts
-        language: system
-        entry: poetry run check-case-conflict
       - id: check-docstring-first
         name: ℹ️  Check docstring is first
         language: system
         types: [python]
         entry: poetry run check-docstring-first
-      - id: check-executables-have-shebangs
-        name: 🧐 Check that executables have shebangs
-        language: system
-        types: [text, executable]
-        entry: poetry run check-executables-have-shebangs
-        stages: [pre-commit, pre-push, manual]
-      - id: check-json
-        name: ｛ Check JSON files
-        language: system
-        types: [json]
-        entry: poetry run check-json
-      - id: check-merge-conflict
-        name: 💥 Check for merge conflicts
-        language: system
-        types: [text]
-        entry: poetry run check-merge-conflict
-      - id: check-symlinks
-        name: 🔗 Check for broken symlinks
-        language: system
-        types: [symlink]
-        entry: poetry run check-symlinks
-      - id: check-toml
-        name: ✅ Check TOML files
-        language: system
-        types: [toml]
-        entry: poetry run check-toml
-      - id: check-xml
-        name: ✅ Check XML files
-        entry: check-xml
-        language: system
-        types: [xml]
-      - id: check-yaml
-        name: ✅ Check YAML files
-        language: system
-        types: [yaml]
-        entry: poetry run check-yaml
       - id: codespell
         name: ✅ Check code for common misspellings
         language: system
@@ -74,31 +34,12 @@ repos:
         entry: poetry run codespell
         args:
           - --ignore-words-list=Januar,sie,als,guerilla,vor,fiel,probleme,tages,ist,handel,normale,alle,carmel
-      - id: detect-private-key
-        name: 🕵️  Detect Private Keys
-        language: system
-        types: [text]
-        entry: poetry run detect-private-key
-      - id: end-of-file-fixer
-        name: ⮐  Fix End of Files
-        language: system
-        types: [text]
-        entry: poetry run end-of-file-fixer
-        stages: [pre-commit, pre-push, manual]
       - id: mypy
         name: 🆎 Static type checking using mypy
         language: system
         types: [python]
         entry: poetry run mypy
         require_serial: true
-      - id: no-commit-to-branch
-        name: 🛑 Don't commit to main branch
-        language: system
-        entry: poetry run no-commit-to-branch
-        pass_filenames: false
-        always_run: true
-        args:
-          - --branch=main
       - id: poetry
         name: 📜 Check pyproject with Poetry
         language: system
@@ -122,14 +63,39 @@ repos:
         types: [python]
         entry: poetry run pytest
         pass_filenames: false
-      - id: trailing-whitespace
-        name: ✄  Trim Trailing Whitespace
-        language: system
-        types: [text]
-        entry: poetry run trailing-whitespace-fixer
-        stages: [pre-commit, pre-push, manual]
       - id: yamllint
         name: 🎗  Check YAML files with yamllint
         language: system
         types: [yaml]
         entry: poetry run yamllint
+  - repo: builtin
+    hooks:
+      - id: check-case-conflict
+        name: 🔠 Check for case conflicts
+      - id: check-executables-have-shebangs
+        name: 🧐 Check that executables have shebangs
+        stages: [pre-commit, pre-push, manual]
+      - id: check-json
+        name: ｛ Check JSON files
+      - id: check-merge-conflict
+        name: 💥 Check for merge conflicts
+      - id: check-symlinks
+        name: 🔗 Check for broken symlinks
+      - id: check-toml
+        name: ✅ Check TOML files
+      - id: check-xml
+        name: ✅ Check XML files
+      - id: check-yaml
+        name: ✅ Check YAML files
+      - id: detect-private-key
+        name: 🕵️  Detect Private Keys
+      - id: end-of-file-fixer
+        name: ⮐  Fix End of Files
+        stages: [pre-commit, pre-push, manual]
+      - id: no-commit-to-branch
+        name: 🛑 Don't commit to main branch
+        args:
+          - --branch=main
+      - id: trailing-whitespace
+        name: ✄  Trim Trailing Whitespace
+        stages: [pre-commit, pre-push, manual]

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ npm install
 poetry install
 ```
 
-As this repository uses the [pre-commit][pre-commit] framework, all changes
+As this repository uses the [prek][prek] framework, all changes
 are linted and tested with each commit. You can run all checks and tests
 manually, using the following command:
 
 ```bash
-poetry run pre-commit run --all-files
+poetry run prek run --all-files
 ```
 
 To run just the Python tests:
@@ -121,7 +121,7 @@ SOFTWARE.
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2026.svg
 [poetry-install]: https://python-poetry.org/docs/#installation
 [poetry]: https://python-poetry.org
-[pre-commit]: https://pre-commit.com/
+[prek]: https://prek.j178.dev/
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-stable-green.svg
 [python-versions-shield]: https://img.shields.io/pypi/pyversions/python-overseerr
 [releases-shield]: https://img.shields.io/github/release/joostlek/python-overseerr.svg

--- a/poetry.lock
+++ b/poetry.lock
@@ -365,17 +365,6 @@ files = [
 pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
 
 [[package]]
-name = "cfgv"
-version = "3.5.0"
-description = "Validate configuration and produce human readable error messages."
-optional = false
-python-versions = ">=3.10"
-files = [
-    {file = "cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0"},
-    {file = "cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132"},
-]
-
-[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -767,17 +756,6 @@ graph = ["objgraph (>=1.7.2)"]
 profile = ["gprof2dot (>=2022.7.29)"]
 
 [[package]]
-name = "distlib"
-version = "0.4.0"
-description = "Distribution utilities"
-optional = false
-python-versions = "*"
-files = [
-    {file = "distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16"},
-    {file = "distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d"},
-]
-
-[[package]]
 name = "dparse"
 version = "0.6.4"
 description = "A parser for Python dependency files"
@@ -1004,28 +982,14 @@ socks = ["socksio (==1.*)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
-name = "identify"
-version = "2.6.19"
-description = "File identification library for Python"
-optional = false
-python-versions = ">=3.10"
-files = [
-    {file = "identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a"},
-    {file = "identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842"},
-]
-
-[package.extras]
-license = ["ukkonen"]
-
-[[package]]
 name = "idna"
-version = "3.16"
+version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5"},
-    {file = "idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d"},
+    {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
+    {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
 ]
 
 [package.extras]
@@ -1086,13 +1050,13 @@ files = [
 
 [[package]]
 name = "joserfc"
-version = "1.6.7"
+version = "1.7.0"
 description = "The ultimate Python library for JOSE RFCs, including JWS, JWE, JWK, JWA, JWT"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "joserfc-1.6.7-py3-none-any.whl", hash = "sha256:9e51e4a64840aa1734a058258e80a4480e2ff2d5686e480e7c92c954a92fbe05"},
-    {file = "joserfc-1.6.7.tar.gz", hash = "sha256:6999fe89457069ecacd8cc797c88a805f83054dd883333fa0409f74b46479fd7"},
+    {file = "joserfc-1.7.0-py3-none-any.whl", hash = "sha256:17e5d7a5a35e65442b05efc435a3d5d46696ffa2c8a2ed0eea6f63fc268e3224"},
+    {file = "joserfc-1.7.0.tar.gz", hash = "sha256:4aced6ab0c47846f0a531402aec2419a874b91e918df9c4c9da8a82fb559d6c4"},
 ]
 
 [package.dependencies]
@@ -1636,17 +1600,6 @@ tgrep = ["pyparsing"]
 twitter = ["twython"]
 
 [[package]]
-name = "nodeenv"
-version = "1.10.0"
-description = "Node.js virtual environment builder"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-files = [
-    {file = "nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827"},
-    {file = "nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb"},
-]
-
-[[package]]
 name = "orjson"
 version = "3.11.9"
 description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
@@ -1758,13 +1711,13 @@ re2 = ["google-re2 (>=1.1)"]
 
 [[package]]
 name = "platformdirs"
-version = "4.9.6"
+version = "4.10.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"},
-    {file = "platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a"},
+    {file = "platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a"},
+    {file = "platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7"},
 ]
 
 [[package]]
@@ -1783,24 +1736,6 @@ dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
-name = "pre-commit"
-version = "4.6.0"
-description = "A framework for managing and maintaining multi-language pre-commit hooks."
-optional = false
-python-versions = ">=3.10"
-files = [
-    {file = "pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b"},
-    {file = "pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9"},
-]
-
-[package.dependencies]
-cfgv = ">=2.0.0"
-identify = ">=1.0.0"
-nodeenv = ">=0.11.1"
-pyyaml = ">=5.1"
-virtualenv = ">=20.10.0"
-
-[[package]]
 name = "pre-commit-hooks"
 version = "6.0.0"
 description = "Some out-of-the-box hooks for pre-commit."
@@ -1813,6 +1748,32 @@ files = [
 
 [package.dependencies]
 "ruamel.yaml" = ">=0.15"
+
+[[package]]
+name = "prek"
+version = "0.3.9"
+description = "A Git hook manager written in Rust, designed as a drop-in alternative to pre-commit."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "prek-0.3.9-py3-none-linux_armv6l.whl", hash = "sha256:3ed793d51bfaa27bddb64d525d7acb77a7c8644f549412d82252e3eb0b88aad8"},
+    {file = "prek-0.3.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:399c58400c0bd0b82a93a3c09dc1bfd88d8d0cfb242d414d2ed247187b06ead1"},
+    {file = "prek-0.3.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e2ea1ffb124e92f081b8e2ca5b5a623a733efb3be0c5b1f4b7ffe2ee17d1f20c"},
+    {file = "prek-0.3.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:aaf639f95b7301639298311d8d44aad0d0b4864e9736083ad3c71ce9765d37ab"},
+    {file = "prek-0.3.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ff104863b187fa443ea8451ca55d51e2c6e94f99f00d88784b5c3c4c623f1ebe"},
+    {file = "prek-0.3.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:039ecaf87c63a3e67cca645ebd5bc5eb6aafa6c9d929e9a27b2921e7849d7ef9"},
+    {file = "prek-0.3.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3bde2a3d045705095983c7f78ba04f72a7565fe1c2b4e85f5628502a254754ff"},
+    {file = "prek-0.3.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28a0960a21543563e2c8e19aaad176cc8423a87aac3c914d0f313030d7a9244a"},
+    {file = "prek-0.3.9-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:0dfb5d5171d7523271909246ee306b4dc3d5b63752e7dd7c7e8a8908fc9490d1"},
+    {file = "prek-0.3.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82b791bd36c1430c84d3ae7220a85152babc7eaf00f70adcb961bd594e756ba3"},
+    {file = "prek-0.3.9-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:6eac6d2f736b041118f053a1487abed468a70dd85a8688eaf87bb42d3dcecf20"},
+    {file = "prek-0.3.9-py3-none-musllinux_1_1_i686.whl", hash = "sha256:5517e46e761367a3759b3168eabc120840ffbca9dfbc53187167298a98f87dc4"},
+    {file = "prek-0.3.9-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:92024778cf78683ca32687bb249ab6a7d5c33887b5ee1d1a9f6d0c14228f4cf3"},
+    {file = "prek-0.3.9-py3-none-win32.whl", hash = "sha256:7f89c55e5f480f5d073769e319924ad69d4bf9f98c5cb46a83082e26e634c958"},
+    {file = "prek-0.3.9-py3-none-win_amd64.whl", hash = "sha256:7722f3372eaa83b147e70a43cb7b9fe2128c13d0c78d8a1cdbf2a8ec2ee071eb"},
+    {file = "prek-0.3.9-py3-none-win_arm64.whl", hash = "sha256:0bced6278d6cc8a4b46048979e36bc9da034611dc8facd77ab123177b833a929"},
+    {file = "prek-0.3.9.tar.gz", hash = "sha256:f82b92d81f42f1f90a47f5fbbf492373e25ef1f790080215b2722dd6da66510e"},
+]
 
 [[package]]
 name = "propcache"
@@ -2203,25 +2164,6 @@ pytest = ">=7"
 
 [package.extras]
 testing = ["process-tests", "pytest-xdist", "virtualenv"]
-
-[[package]]
-name = "python-discovery"
-version = "1.3.1"
-description = "Python interpreter discovery"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "python_discovery-1.3.1-py3-none-any.whl", hash = "sha256:ed188687ebb3b82c01a17cd5ac62fc94d9f6487a7f1a0f9dfe89753fec91039c"},
-    {file = "python_discovery-1.3.1.tar.gz", hash = "sha256:62f6db28064c9613e7ca76cb3f00c38c839a07c31c00dfe7ed0986493d2150a6"},
-]
-
-[package.dependencies]
-filelock = ">=3.15.4"
-platformdirs = ">=4.3.6,<5"
-
-[package.extras]
-docs = ["furo (>=2025.12.19)", "sphinx (>=9.1)", "sphinx-autodoc-typehints (>=3.6.3)", "sphinxcontrib-mermaid (>=2)", "sphinxcontrib-towncrier (>=0.4)", "towncrier (>=25.8)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.5.4)", "pytest (>=8.3.5)", "pytest-mock (>=3.14)", "setuptools (>=75.1)"]
 
 [[package]]
 name = "pyyaml"
@@ -2638,18 +2580,18 @@ telegram = ["requests"]
 
 [[package]]
 name = "typer"
-version = "0.25.1"
+version = "0.26.6"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89"},
-    {file = "typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc"},
+    {file = "typer-0.26.6-py3-none-any.whl", hash = "sha256:49f96d9ee5730cef607bbe155042f40b41fa4c0d0dec04990d580837493805be"},
+    {file = "typer-0.26.6.tar.gz", hash = "sha256:cdbc160fe7e795b835fb6016419494a521a67bfb86b9476a1ccd0e7727d3ae5b"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
-click = ">=8.2.1"
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
 rich = ">=13.8.0"
 shellingham = ">=1.3.0"
 
@@ -2694,23 +2636,6 @@ brotli = ["brotli (>=1.2.0)", "brotlicffi (>=1.2.0.0)"]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["backports-zstd (>=1.0.0)"]
-
-[[package]]
-name = "virtualenv"
-version = "21.3.3"
-description = "Virtual Python Environment builder"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "virtualenv-21.3.3-py3-none-any.whl", hash = "sha256:7d5987d8369e098e41406efb780a3d4ca79280097293899e351a6407ee153ab3"},
-    {file = "virtualenv-21.3.3.tar.gz", hash = "sha256:f5bda277e553b1c2b3c1a8debfc30496e1288cc93ce6b7b71b3280047e317328"},
-]
-
-[package.dependencies]
-distlib = ">=0.3.7,<1"
-filelock = {version = ">=3.24.2,<4", markers = "python_version >= \"3.10\""}
-platformdirs = ">=3.9.1,<5"
-python-discovery = ">=1.3.1"
 
 [[package]]
 name = "yamllint"
@@ -2851,4 +2776,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.13"
-content-hash = "244f2b30e34feadfcafd1b03808c97769d47335bfbe38169e732559e9394c6a5"
+content-hash = "60022e2693f1d29b49c5d02c89d7141c75ba831fd71361e5ebacdf9df729e6d5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,12 @@ mashumaro = "^3.11"
 orjson = ">=3.9.0"
 
 [tool.poetry.group.dev.dependencies]
+aiohttp = "<3.14"  # aioresponses 0.7.8 incompatible with aiohttp 3.14
 codespell = "2.4.2"
 covdefaults = "2.3.0"
 coverage = {version = "7.14.1", extras = ["toml"]}
 mypy = "1.20.2"
-pre-commit = "4.6.0"
+prek = "0.3.9"
 pre-commit-hooks = "6.0.0"
 pylint = "4.0.5"
 pytest = "9.0.3"


### PR DESCRIPTION
Migrate from pre-commit to prek.

- Move builtin hooks (check-case-conflict, check-executables-have-shebangs, check-json, check-merge-conflict, check-symlinks, check-toml, check-xml, check-yaml, detect-private-key, end-of-file-fixer, no-commit-to-branch, trailing-whitespace) from `local` to a new `builtin` repo block in `.pre-commit-config.yaml`.
- Replace `pre-commit` dev dependency with `prek` 0.3.9 in `pyproject.toml`.
- Add `prek-builtin-hooks` job in linting workflow using `pipx install prek` (no Poetry/Python setup) with one step per builtin hook.
- Remove builtin hook steps from `pre-commit-hooks` job and rename `pre-commit run` -> `prek run` throughout workflows.
- Update README to reference [prek](https://prek.j178.dev/).
- Add `[*.yaml] indent_size = 2` to `.editorconfig`.
- Regenerate `poetry.lock`.